### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - mkdir -p ~/.config/cldf/
   - (cd ~/.config/cldf/ && [ -d glottolog ] || git clone --depth 1 https://github.com/glottolog/glottolog.git)
   - (cd ~/.config/cldf/ && [ -d concepticon-data ] || git clone --depth 1 https://github.com/concepticon/concepticon-data.git concepticon)
-  - (cd ~/.config/cldf/ && [ -d clts ] || git clone --depth 1 https://github.com/cldf-clts/clts.git)
+  - (cd ~/.config/cldf/ && [ -d clts ] || git clone -b v1.4.1 --depth 1 https://github.com/cldf-clts/clts.git)
   - pip install cldfbench pyglottolog pyconcepticon pyclts
   - cldfbench catconfig
   - cldfbench catinfo

--- a/src/lexedata/exporter/phylogenetics.py
+++ b/src/lexedata/exporter/phylogenetics.py
@@ -241,6 +241,8 @@ def build_lang_ids(dataset, col_map):
             lang_ids[row[col_map.id]] = row[col_map.id]
         if row.get(col_map.glottocode):
             language_code_map[lang_ids[row[col_map.id]]] = row[col_map.glottocode]
+    lang_ids = dict(sorted(lang_ids.items()))
+    language_code_map = dict(sorted(language_code_map.items()))
     return lang_ids, language_code_map
 
 


### PR DESCRIPTION
Due to an update in CLTS, the interplay between cldfbench and the CLTS data was broken. Fix the CLTS catalogue clone to a specific tagged version, in a very blunt way (we want to avoid downloading a giant repository to travis).