### PR TITLE
Script to guess metadata for a metadata-free wordlist

### DIFF
--- a/src/lexedata/change/clean_ids.py
+++ b/src/lexedata/change/clean_ids.py
@@ -23,10 +23,10 @@ def clean_mapping(rows: t.Mapping[str, t.Mapping[str, str]]) -> t.Mapping[str, s
     """Create unique normalized IDs.
 
     >>> clean_mapping({"A": {}, "B": {}})
-    {"A": "a", "B": "b"}
+    {'A': 'a', 'B': 'b'}
 
     >>> clean_mapping({"A": {}, "a": {}})
-    {"A": "a", "a": "a_x2"}
+    {'A': 'a', 'a': 'a_x2'}
     """
     avoid = {id.lower() for id in rows}
 

--- a/src/lexedata/change/rename_concept.py
+++ b/src/lexedata/change/rename_concept.py
@@ -4,6 +4,8 @@ import typing as t
 from lexedata.enrich.add_status_column import add_status_column_to_table
 import lexedata.cli as cli
 
+# TODO: use lexedata.change.clean_ids.update_ids
+
 
 def substitute_many(
     row, columns, old_values_to_new_values, status_update: t.Optional[str]

--- a/src/lexedata/change/rename_language.py
+++ b/src/lexedata/change/rename_language.py
@@ -4,6 +4,9 @@ import typing as t
 from lexedata.enrich.add_status_column import add_status_column_to_table
 import lexedata.cli as cli
 
+# TODO: use lexedata.change.clean_ids.update_ids
+# TODO: share more functionality with rename_concept
+
 
 def substitute_many(
     row, columns, old_values_to_new_values, status_update: t.Optional[str]

--- a/src/lexedata/change/unicodenormalize.py
+++ b/src/lexedata/change/unicodenormalize.py
@@ -4,3 +4,18 @@ Maybe this should be one of the extended checks, with automatic fixing option, i
 
 This funtionality is, without error reporting, in the CLI of lexedata.util
 """
+
+from pathlib import Path
+import unicodedata
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Recode all data in NFC unicode normalization"
+    )
+    parser.add_argument("file", nargs="+", type=Path)
+    args = parser.parse_args()
+    for file in args.file:
+        content = file.open().read()
+        file.open("w").write(unicodedata.normalize("NFC", content))

--- a/src/lexedata/cli.py
+++ b/src/lexedata/cli.py
@@ -6,6 +6,7 @@ import typing as t
 import tqdm
 
 logger = logging.getLogger("lexedata")
+logging.basicConfig(level=logging.INFO)
 
 
 def tq(iter, logger=logger, total: t.Optional[t.Union[int, float]] = None):

--- a/src/lexedata/enrich/add_free_metadata.py
+++ b/src/lexedata/enrich/add_free_metadata.py
@@ -1,0 +1,153 @@
+"""Starting with a forms.csv, add metadata for all columns we know about.
+"""
+
+from pathlib import Path
+
+import pycldf
+from csvw.dsv import iterrows
+from csvw.metadata import Column, Datatype
+
+from lexedata import cli
+
+DEFAULT_NAME_COLUMNS = {
+    column.name: column
+    for column in (term.to_column() for term in pycldf.TERMS.values())
+}
+
+LEXEDATA_COLUMNS = {
+    "Status": Column(
+        datatype=Datatype(base="string"),
+        default="",
+        lang="eng",
+        null=[""],
+        name="Value",
+        aboutUrl="...",
+    ),
+    "Orthographic": Column(
+        datatype=Datatype(base="string"),
+        default="",
+        null=[""],
+        name="Orthographic",
+        aboutUrl="...",
+    ),
+    "Phonemic": Column(
+        datatype=Datatype(base="string"),
+        default="",
+        null=[""],
+        name="Phonemic",
+        aboutUrl="...",
+    ),
+    "Phonetic": Column(
+        datatype=Datatype(base="string"),
+        default="",
+        null=[""],
+        name="Phonetic",
+        aboutUrl="...",
+    ),
+    "Variants": Column(
+        datatype=Datatype(base="string", format=r"\s*(~|)\s*[[/(].*[]/)]\s*"),
+        separator=",",
+        default="",
+        null=[""],
+        name="Variants",
+    ),
+    "Tags": Column(
+        datatype=Datatype(base="string"),
+        separator=",",
+        default="",
+        null=[""],
+        name="Tags",
+    ),
+    "Loan": Column(
+        datatype=Datatype(base="string"),
+        default="",
+        null=[""],
+        name="Loan",
+        aboutUrl="...",
+    ),
+}
+
+LINGPY_COLUMNS = {
+    "IPA": pycldf.TERMS["form"].to_column(),
+    "DOCULECT": pycldf.TERMS["languageReference"].to_column(),
+}
+
+OTHER_KNOWN_COLUMNS = {
+    "Form_according_to_Source": Column(
+        datatype=Datatype(base="string"),
+        default="",
+        null=[""],
+        name="Form_according_to_Source",
+        required=True,
+    ),
+    "Page": Column(
+        datatype=Datatype(base="string", format=r"\d+(-\d+)?"),
+        separator=",",
+        default="",
+        null=["", "?"],
+        name="Page",
+    ),
+}
+
+
+if __name__ == "__main__":
+    parser = cli.parser(__doc__)
+    args = parser.parse_args()
+    logger = cli.setup_logging(args)
+
+    # TODO, maybe: allow specification of the file by command line option. In that
+    # case, check for name and extension and make sure to write the metadata to
+    # the same folder.
+    fname = Path("forms.csv")
+
+    ds = pycldf.Wordlist.from_data(fname)
+    # `from_data` checks that the reqired columns of the FormTable are present,
+    # but it does not consolidate the columns further.
+
+    colnames = next(iterrows(fname))
+
+    understood_colnames = {
+        c.name for c in ds[ds.primary_table].tableSchema.columns if c.name in colnames
+    }
+
+    # Consider the columns that were not understood.
+    columns_without_metadata = set(colnames) - understood_colnames
+    for column_name in columns_without_metadata:
+        column: Column
+        # Maybe they are known CLDF properties?
+        if column_name in pycldf.terms.TERMS:
+            column = pycldf.TERMS[column_name].to_column()
+            column.name = column_name
+        # Maybe they are CLDF default column names?
+        elif column_name in DEFAULT_NAME_COLUMNS:
+            column = DEFAULT_NAME_COLUMNS[column_name]
+        # Maybe they are columns that Lexedata knows to handle?
+        elif column_name in LEXEDATA_COLUMNS:
+            column = LEXEDATA_COLUMNS[column_name]
+        # Maybe they are columns inherited from LingPy?
+        elif column_name.upper() in LINGPY_COLUMNS:
+            column = LINGPY_COLUMNS[column_name.upper()]
+            column.name = column_name
+        # Maybe they are some name we have seen before?
+        elif column_name in OTHER_KNOWN_COLUMNS:
+            column = OTHER_KNOWN_COLUMNS[column_name]
+        else:
+            # Maybe they look like they have a specific type?
+            ...
+            # Otherwise, they are probably just text to be kept.
+            column = Column(
+                datatype=Datatype(base="string"),
+                default="",
+                null=[""],
+                name=column_name,
+            )
+
+        ds[ds.primary_table].tableSchema.columns.append(column)
+
+    ds[ds.primary_table].tableSchema.columns.sort(
+        key=lambda k: colnames.index(k.name) if k.name in colnames else 1e10
+    )
+
+    ds.write_metadata(args.metadata)
+
+    ds.validate(log=logger)

--- a/src/lexedata/enrich/add_free_metadata.py
+++ b/src/lexedata/enrich/add_free_metadata.py
@@ -90,16 +90,11 @@ OTHER_KNOWN_COLUMNS = {
 }
 
 
-if __name__ == "__main__":
-    parser = cli.parser(__doc__)
-    args = parser.parse_args()
-    logger = cli.setup_logging(args)
-
-    # TODO, maybe: allow specification of the file by command line option. In that
-    # case, check for name and extension and make sure to write the metadata to
-    # the same folder.
-    fname = Path("forms.csv")
-
+def add_metadata(fname: Path):
+    if fname.name != "forms.csv":
+        raise ValueError(
+            "A metadata-free Wordlist must be in a file called 'forms.csv'."
+        )
     ds = pycldf.Wordlist.from_data(fname)
     # `from_data` checks that the reqired columns of the FormTable are present,
     # but it does not consolidate the columns further.
@@ -147,6 +142,17 @@ if __name__ == "__main__":
     ds[ds.primary_table].tableSchema.columns.sort(
         key=lambda k: colnames.index(k.name) if k.name in colnames else 1e10
     )
+    return ds
+
+
+if __name__ == "__main__":
+    parser = cli.parser(__doc__)
+    args = parser.parse_args()
+    logger = cli.setup_logging(args)
+
+    fname = Path("forms.csv")
+
+    ds = add_metadata(fname)
 
     ds.write_metadata(args.metadata)
 

--- a/src/lexedata/exporter/edictor.py
+++ b/src/lexedata/exporter/edictor.py
@@ -9,8 +9,8 @@ import typing as t
 import pycldf
 
 
-from lexedata.util import parse_segment_slices as segment_slices_to_segment_list
 import lexedata.cli as cli
+from lexedata.util import parse_segment_slices
 
 
 def rename(form_column, dataset):
@@ -110,7 +110,7 @@ def forms_to_tsv(
                 which_segment_belongs_to_which_cognateset[j[c_cognate_form]] = [
                     None for _ in form[c_form_segments]
                 ]
-            segments_judged = segment_slices_to_segment_list(
+            segments_judged = parse_segment_slices(
                 segments=form[c_form_segments], judgement=j
             )
             for s in segments_judged:

--- a/src/lexedata/report/nonconcatenative_morphemes.py
+++ b/src/lexedata/report/nonconcatenative_morphemes.py
@@ -3,9 +3,8 @@ from pathlib import Path
 
 import pycldf
 
-
-from lexedata.util import parse_segment_slices as segment_slices_to_segment_list
 import lexedata.cli as cli
+from lexedata.util import parse_segment_slices
 
 
 def segment_to_cognateset(dataset: pycldf.Dataset, cognatesets: t.Iterable):
@@ -31,7 +30,7 @@ def segment_to_cognateset(dataset: pycldf.Dataset, cognatesets: t.Iterable):
                 which_segment_belongs_to_which_cognateset[j[c_cognate_form]] = [
                     set() for _ in form[c_form_segments]
                 ]
-            segments_judged = segment_slices_to_segment_list(
+            segments_judged = parse_segment_slices(
                 segments=form[c_form_segments], judgement=j
             )
             for s in segments_judged:

--- a/src/lexedata/util.py
+++ b/src/lexedata/util.py
@@ -247,16 +247,3 @@ class KeyKeyDict(t.Mapping[str, str]):
 
     def __getitem__(self, key):
         return key
-
-
-if __name__ == "__main__":
-    import argparse
-
-    parser = argparse.ArgumentParser(
-        description="Recode all data in NFC unicode normalization"
-    )
-    parser.add_argument("file", nargs="+", type=Path)
-    args = parser.parse_args()
-    for file in args.file:
-        content = file.open().read()
-        file.open("w").write(unicodedata.normalize("NFC", content))

--- a/src/lexedata/util.py
+++ b/src/lexedata/util.py
@@ -14,6 +14,7 @@ from lingpy.compare.strings import ldn_swap
 
 import csvw
 from lexedata.cli import tq
+from lexedata.enrich.add_free_metadata import add_metadata
 
 ID_FORMAT = re.compile("[a-z0-9_]+")
 
@@ -185,8 +186,7 @@ def make_temporary_dataset(form_table):
     form_table_file_name = directory / "forms.csv"
     with form_table_file_name.open("w") as form_table_file:
         form_table_file.write(form_table)
-    # Maybe guess metadata?
-    dataset = pycldf.Wordlist.from_data(form_table_file_name)
+    dataset = add_metadata(form_table_file_name)
     dataset.write(directory / "Wordlist-metadata.json")
     return dataset
 
@@ -208,15 +208,15 @@ def cache_table(
     Examples
     ========
 
-    >>> ds = make_temporary_dataset('''ID,Language_ID,Parameter_ID,Form
-    ... ache_one,ache,one,"e.ta.'kɾã"
+    >>> ds = make_temporary_dataset('''ID,Language_ID,Parameter_ID,Form,variants
+    ... ache_one,ache,one,"e.ta.'kɾã",~[testphoneticvariant]
     ... ''')
     >>> forms = cache_table(ds)
     >>> forms["ache_one"]["languageReference"]
     'ache'
     >>> forms["ache_one"]["form"]
     "e.ta.'kɾã"
-    >>> #forms["ache_one"]["variants"] == ['~[test_variant with various comments]']
+    >>> forms["ache_one"]["variants"] == ['~[test_variant with various comments]']
 
     We can also use it to look up a specific set of columns, and change the index column.
     This allows us, for example, to get language IDs by name:

--- a/src/lexedata/util.py
+++ b/src/lexedata/util.py
@@ -221,12 +221,13 @@ def cache_table(
 
     We can also use it to look up a specific set of columns, and change the index column.
     This allows us, for example, to get language IDs by name:
-
-    languages = cache_table(ds, "LanguageTable", {"id": "ID"}, index_column="Name")
-    languages == {'Aché': {'id': 'ache'},
-                  'Paraguayan Guaraní': {'id': 'paraguayan_guarani'},
-                  'Old Paraguayan Guaraní': {'id': 'old_paraguayan_guarani'},
-                  'Kaiwá': {'id': 'kaiwa'}}
+    >>> _ = ds.add_component("LanguageTable")
+    >>> ds.write(LanguageTable=[
+    ...     ['ache', 'Aché', 'South America', -25.59, -56.47, "ache1246", "guq"],
+    ...     ['paraguayan_guarani', 'Paraguayan Guaraní', None, None, None, None, None]])
+    >>> languages = cache_table(ds, "LanguageTable", {"id": "ID"}, index_column="Name")
+    >>> languages == {'Aché': {'id': 'ache'},
+    ...               'Paraguayan Guaraní': {'id': 'paraguayan_guarani'}}
     True
 
     In this case identical values later in the file overwrite earlier ones.

--- a/src/lexedata/util.py
+++ b/src/lexedata/util.py
@@ -208,15 +208,16 @@ def cache_table(
     Examples
     ========
 
-    >>> ds = make_temporary_dataset('''ID,Language_ID,Parameter_ID,Form,variants
-    ... ache_one,ache,one,"e.ta.'kɾã",~[testphoneticvariant]
+    >>> ds = make_temporary_dataset('''ID,Language_ID,Parameter_ID,Form,Variants
+    ... ache_one,ache,one,"e.ta.'kɾã",~[test phonetic variant]
     ... ''')
     >>> forms = cache_table(ds)
     >>> forms["ache_one"]["languageReference"]
     'ache'
     >>> forms["ache_one"]["form"]
     "e.ta.'kɾã"
-    >>> forms["ache_one"]["variants"] == ['~[test_variant with various comments]']
+    >>> forms["ache_one"]["Variants"]
+    ['~[test phonetic variant]']
 
     We can also use it to look up a specific set of columns, and change the index column.
     This allows us, for example, to get language IDs by name:


### PR DESCRIPTION
The LingPy interface, like all our LingPy interfaces, is insufficient – If a
word list lacks form and languageReference column, that's an error, so mapping
those properties to LingPy column names does not help.

Fixes #117

Any idea how to write tests for this? I guess the first step will be wrapping steps into functions.

@nataliacp and @PaprikaSteiger What other columns do we know about that aren't just text or already in CLDF?
