### PR TITLE
fix: dir pattern for data-package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include lexedata/* clics3-network.gml.zip
+recursive-include src/* clics3-network.gml.zip


### PR DESCRIPTION
Sorry, I was wrong in previous time, now it should work fine

it either should start from `src` or have `**` to recursively matches zero or more directories (`recursive-include **/data clics3-network.gml.zip`)