### PR TITLE
List arguments

### DIFF
--- a/docs/tour.rst
+++ b/docs/tour.rst
@@ -69,8 +69,9 @@ This is one of several formats supported by lexedata for import. The
 corresponding importer is called ``excel_interleaved`` and it works like this::
 
     $ python -m lexedata.importer.excel_interleaved --help
-    usage: excel_interleaved.py [-h] [--sheet SHEET] [--directory DIRECTORY]
-                                [--loglevel LOGLEVEL] [-q] [-v]
+    usage: excel_interleaved.py [-h] [--sheets SHEET [SHEET ...]]
+                                [--directory DIRECTORY] [--loglevel LOGLEVEL] [-q]
+                                [-v]
                                 EXCEL
 
     Import data in the "interleaved" format from an Excel spreadsheet. [...]
@@ -81,10 +82,11 @@ corresponding importer is called ``excel_interleaved`` and it works like this::
 
     option[...]:
       -h, --help            show this help message and exit
-      --sheet SHEET         Excel sheet name(s) to import (default: all sheets)
+      --sheets SHEET [SHEET ...]
+                            Excel sheet name(s) to import (default: all sheets)
       --directory DIRECTORY
-                            Path to directory where forms.csv is created (default:
-                            current working directory)
+                            Path to directory where forms.csv is to be created
+                            (default: current working directory)
 
     Logging:
       --loglevel LOGLEVEL
@@ -464,7 +466,7 @@ tell ``clean_forms`` about new separators and re-run::
     $ git checkout .
     Updated 2 paths from the index
     $ sed -i.bak -e '/kikuyu_long_s2/s/(be long/(be long)/' forms.csv
-    $ python -m lexedata.edit.clean_forms -k '~' -k '*' -s ',' -s ';' -s '/'
+    $ python -m lexedata.edit.clean_forms -k '~' '*' -s ',' ';' '/'
     INFO:lexedata:Line 66: Split form 'pɔ́ / ewɔ́' into 2 elements.
     [...]
     INFO:lexedata:Line 588: Split form 'lə̀-náàŋgá * náàŋgá' into 2 elements.

--- a/src/lexedata/cli.py
+++ b/src/lexedata/cli.py
@@ -108,6 +108,9 @@ class ListOrFromFile(argparse.Action):
         )
 
     def __call__(self, parser, namespace, values, option_string=None):
+        # This coud be improved if we could defer this until the dataset has
+        # been loaded; but that requires major changes to the action reading
+        # --metadata.
         if len(values) == 0:
             # Keep default value
             return

--- a/src/lexedata/cli.py
+++ b/src/lexedata/cli.py
@@ -1,3 +1,4 @@
+import csv
 import sys
 import logging
 import argparse
@@ -6,6 +7,8 @@ from enum import IntEnum
 from pathlib import Path
 
 import tqdm
+
+from lexedata import types
 
 logger = logging.getLogger("lexedata")
 logging.basicConfig(level=logging.INFO)
@@ -51,6 +54,84 @@ class ChangeLoglevel(argparse.Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, getattr(namespace, self.dest) + self.change)
+
+
+class ListOrFromFile(argparse.Action):
+    def __init__(
+        self,
+        option_strings,
+        dest,
+        nargs="+",
+        default=types.WorldSet(),
+        help=None,
+        autohelp=True,
+        metavar=None,
+        **kwargs,
+    ):
+        if nargs != "+":
+            if (
+                len(option_strings) == 1
+                and nargs == "*"
+                and not option_strings[0].startswith("-")
+            ):
+                # Mandatory argument, can be not given as default.
+                pass
+            else:
+                raise ValueError(
+                    "Optional ListOrFromFile makes sense only with variable argument count ('+)"
+                )
+
+        if metavar is None:
+            metavar = option_strings[0].upper()
+            if option_strings[0].endswith("s"):
+                metavar = metavar[:-1]
+            if option_strings[0].startswith("--"):
+                metavar = metavar[2:]
+
+        if autohelp:
+            help = (
+                (help or "")
+                + f" Instead of a list of individual {metavar}s on the command line, this argument accepts also the path to a single {metavar}S.CSV file (with header row), containing the relevant IDs in the first column."
+            )
+            if type(default) == types.WorldSet:
+                help += f" (default: All {metavar.lower()}s in the dataset)"
+            help = help.strip()
+
+        super().__init__(
+            option_strings,
+            dest,
+            nargs=nargs,
+            default=default,
+            help=help,
+            metavar=metavar,
+            **kwargs,
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if len(values) == 0:
+            # Keep default value
+            return
+        if len(values) == 1:
+            path = Path(values[0])
+            if path.exists():
+                values = []
+                for c, concept in enumerate(csv.reader(path.open())):
+                    first_column = concept[0]
+                    if c == 0:
+                        logger.info(
+                            "Reading concept IDs from column with header %s",
+                            first_column,
+                        )
+                    else:
+                        values.append(first_column)
+                setattr(namespace, self.dest, values)
+                return
+            logger.debug(
+                "File %s not found, assuming you want a single %s",
+                path,
+                str(option_string).lstrip("-").rstrip("s"),
+            )
+        setattr(namespace, self.dest, values)
 
 
 def add_log_controls(parser: argparse.ArgumentParser):

--- a/src/lexedata/edit/add_concepticon.py
+++ b/src/lexedata/edit/add_concepticon.py
@@ -244,12 +244,12 @@ if __name__ == "__main__":
         help="Add/update a column containing Concepticon's concept set definitions, for quick disambiguation",
     )
     parser.add_argument(
-        "--gloss-language",
+        "--gloss-languages",
         "-l",
-        action="append",
-        default=[],
+        nargs="+",
+        default=None,
         type=equal_separated,
-        help="Maps from column names to 2-letter language codes. For example, if your ParameterTable has a column 'GLOSS', which contains English glosses, and a colum 'PORTUGUESE' with Portuguese translations, run this script with the arguments `-l GLOSS=en -l PORTUGUESE=pt`. If no language mappings are given, the assumption is that the #id column contains English glosses.",
+        help="Maps from column names to 2-letter language codes. For example, if your ParameterTable has a column 'GLOSS', which contains English glosses, and a colum 'PORTUGUESE' with Portuguese translations, run this script with the arguments `-l GLOSS=en PORTUGUESE=pt`. If no language mappings are given, the assumption is that the #id column contains English glosses.",
     )
     parser.add_argument(
         "--status-update",
@@ -264,7 +264,7 @@ if __name__ == "__main__":
 
     create_concepticon_for_concepts(
         dataset=pycldf.Wordlist.from_metadata(args.metadata),
-        language=args.gloss_language,
+        language=args.gloss_languages,
         concepticon_glosses=args.add_concept_set_names,
         concepticon_definition=args.add_definitions,
         overwrite=args.overwrite,

--- a/src/lexedata/edit/add_segments.py
+++ b/src/lexedata/edit/add_segments.py
@@ -1,24 +1,12 @@
 """Segment the form.
 
+
 Take a form, in a phonemic transcription compatible with IPA, and split it into
 phonemic segments, which are written back to the Segments column of the
 FormTable. Segmentation essentially uses `CLTS`_, including diphthongs and affricates.
 
 
-Details on the segmentation procedure
--------------------------------------
-
-First, apply some pre-processing replacements. Forms supplied contain all
-sorts of noise and lookalike symbols. This function comes with reasonable
-defaults, but if you encounter other problems, or you actually want to be
-strict about IPA transcriptions, pass a dictionary of your choice as
-`pre_replace`.
-
-Then, naïvely segment the form using the IPA tokenizer from the `segments`
-package. Check each returned segment to see whether it is valid according to
-CLTS's BIPA, and if not, try to fix some issues – in particular pre-aspirated
-or pre-nasalized consonants showing up as post-aspirated resp. post-nasalized
-vowels, which BIPA does not accept.
+For details on the segmentation procedure, see the manual.
 
 .. _CLTS: https://clts.clld.org/parameters
 """

--- a/src/lexedata/edit/add_status_column.py
+++ b/src/lexedata/edit/add_status_column.py
@@ -37,8 +37,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--exclude",
         type=str,
+        nargs="*",
         default=[],
-        action="append",
         help="Table names to exclude (takes precedence over table-names)",
         metavar="TABLE",
     )

--- a/src/lexedata/edit/clean_forms.py
+++ b/src/lexedata/edit/clean_forms.py
@@ -199,24 +199,25 @@ if __name__ == "__main__":
     parser.add_argument(
         "--brackets",
         "-b",
-        action="append",
+        metavar="LR",
+        nargs="+",
         default=[],
-        help="Remove brackets from forms, generating variants and comments.",
+        help="Remove brackets from forms, generating variants and comments. Every LR must be a two-character string where L is the left bracket and R is the right bracket.",
     )
 
     parser.add_argument(
         "--separator",
         "-s",
-        action="append",
-        default=[],
-        help="Take SEPARATOR as a separator between forms. If no SEPARATORs are given, use tilde '~', comma ',' and semicolon ';'.",
+        nargs="*",
+        default=None,
+        help="Take SEPARATOR as a separator between forms. If --separator is not given, use tilde '~', comma ',' and semicolon ';'.",
     )
     parser.add_argument(
         "--keep",
         "-k",
-        action="append",
-        default=[],
-        help="Take KSEPARATOR as a separator between forms, but include it in front of a variant. If no KSEPARATOR is given, keep '~' and none of the other separators.",
+        nargs="*",
+        default=None,
+        help="Take KSEPARATOR as a separator between forms, but include it in front of a variant. If --keep is not given, keep '~' and none of the other separators.",
         metavar="KSEPARATOR",
     )
 
@@ -227,9 +228,9 @@ if __name__ == "__main__":
 
     if not args.brackets:
         args.brackets = [("(", ")")]
-    if not args.separator:
+    if args.separator is None:
         args.separator = ["~", ",", ";"]
-    if not args.keep:
+    if args.keep is None:
         kseparators = {"~"}.intersection(args.separator)
     else:
         kseparators = set(args.keep)

--- a/src/lexedata/edit/simplify_ids.py
+++ b/src/lexedata/edit/simplify_ids.py
@@ -1,4 +1,4 @@
-"""Clean up all ID columns in the datasat.
+"""Clean up all ID columns in the dataset.
 
 Take every ID column and convert it to either an integer-valued or a restricted-string-valued (only containing a-z, 0-9, or _) column, maintaining uniqueness of IDs, and keeping IDs as they are where they fit the format.
 

--- a/src/lexedata/edit/simplify_ids.py
+++ b/src/lexedata/edit/simplify_ids.py
@@ -31,10 +31,9 @@ if __name__ == "__main__":
         help="Normalize to uppercase letters, instead of the default lowercase.",
     )
     parser.add_argument(
-        "--table",
-        action="append",
-        default=[],
-        help="Only fix the IDs of this table.",
+        "--tables",
+        nargs="+",
+        help="Only fix the IDs of these tables.",
     )
     args = parser.parse_args()
     logger = cli.setup_logging(args)
@@ -45,9 +44,9 @@ if __name__ == "__main__":
 
     ds = pycldf.Wordlist.from_metadata(args.metadata)
 
-    if args.table:
+    if args.tables:
         tables = []
-        for table in args.table:
+        for table in args.tables:
             try:
                 tables.append(ds[table])
             except KeyError:

--- a/src/lexedata/exporter/edictor.py
+++ b/src/lexedata/exporter/edictor.py
@@ -419,44 +419,20 @@ if __name__ == "__main__":
     parser = cli.parser(
         description="Export #FormTable to tsv format for import to edictor"
     )
-    # TODO: set these arguments correctly
-    # TODO: allow reading from a file instead of from command line, maybe as only option.
     parser.add_argument(
         "--languages",
-        type=str,
-        nargs="*",
-        default=[],
-        help="Language references for form selection",
-        metavar="LANGUAGE",
-    )
-    parser.add_argument(
-        "--languages-file",
-        type=Path,
-        help="If both LANGUAGES_FILE and LANGUAGE are given, take the union.",
+        action=cli.ListOrFromFile,
+        help="Export only forms from these languages.",
     )
     parser.add_argument(
         "--concepts",
-        type=str,
-        nargs="*",
-        default=[],
-        help="",
-    )
-    parser.add_argument(
-        "--concepts-file",
-        type=Path,
-        help="",
+        action=cli.ListOrFromFile,
+        help="Export only forms connected to these concepts.",
     )
     parser.add_argument(
         "--cognatesets",
-        type=str,
-        nargs="*",
-        default=[],
-        help="",
-    )
-    parser.add_argument(
-        "--cognatesets-file",
-        type=Path,
-        help="",
+        action=cli.ListOrFromFile,
+        help="Export only these cognate sets.",
     )
     parser.add_argument(
         "--output-file",
@@ -469,29 +445,11 @@ if __name__ == "__main__":
     logger = cli.setup_logging(args)
     dataset = pycldf.Dataset.from_metadata(args.metadata)
 
-    if args.languages_file:
-        for r, row in enumerate(csv.reader(args.languages_file.open())):
-            if r == 0 and row[0] == dataset["LanguageTable", "id"].name:
-                continue
-            args.languages.append(row[0])
-
-    if args.concepts_file:
-        for r, row in enumerate(csv.reader(args.concepts_file.open())):
-            if r == 0 and row[0] == dataset["ParameterTable", "id"].name:
-                continue
-            args.concepts.append(row[0])
-
-    if args.cognatesets_file:
-        for r, row in enumerate(csv.reader(args.cognatesets_file.open())):
-            if r == 0 and row[0] == dataset["CognatesetTable", "id"].name:
-                continue
-            args.cognatesets.append(row[0])
-
     forms, judgements_about_form, cognateset_mapping = forms_to_tsv(
         dataset=dataset,
-        languages=set(args.languages) or types.WorldSet(),
-        concepts=set(args.concepts) or types.WorldSet(),
-        cognatesets=set(args.cognatesets) or types.WorldSet(),
+        languages=args.languages,
+        concepts=args.concepts,
+        cognatesets=args.cognatesets,
         logger=logger,
     )
 

--- a/src/lexedata/exporter/matrix.py
+++ b/src/lexedata/exporter/matrix.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import re
-import csv
 import typing as t
 from pathlib import Path
 
@@ -80,9 +79,9 @@ if __name__ == "__main__":
         help="File path for the generated cognate excel file.",
     )
     parser.add_argument(
-        "--concept-list",
-        type=Path,
-        help="Output only the concepts listed in this file. I assume that CONCEPT_LIST is a CSV file, and the first comma-separated column contains the ID.",
+        "--concepts",
+        action=cli.ListOrFromFile,
+        help="Concepts to output.",
     )
     parser.add_argument(
         "--sort-languages-by",
@@ -99,21 +98,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
     logger = cli.setup_logging(args)
 
-    concept_list = None
-    if args.concept_list:
-        if not args.concept_list.exists():
-            logger.critical("Concept list file %s not found.", args.concept_list)
-            cli.Exit.FILE_NOT_FOUND()
-        concept_list = []
-        for c, concept in enumerate(csv.reader(args.concept_list.open())):
-            first_column = concept[0]
-            if c == 0:
-                logger.info(
-                    "Reading concept IDs from column with header %s", first_column
-                )
-            else:
-                concept_list.append(first_column)
-
     E = MatrixExcelWriter(
         pycldf.Wordlist.from_metadata(args.metadata),
         database_url=args.url_template,
@@ -122,7 +106,7 @@ if __name__ == "__main__":
     E.create_excel(
         args.excel,
         language_order=args.sort_languages_by,
-        rows=concept_list,
+        rows=args.concepts,
     )
     E.wb.save(
         filename=args.excel,

--- a/src/lexedata/importer/excel_interleaved.py
+++ b/src/lexedata/importer/excel_interleaved.py
@@ -119,6 +119,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--sheets",
+        metavar="SHEET",
         nargs="+",
         default=[],
         help="Excel sheet name(s) to import (default: all sheets)",

--- a/src/lexedata/importer/excel_interleaved.py
+++ b/src/lexedata/importer/excel_interleaved.py
@@ -118,8 +118,8 @@ if __name__ == "__main__":
         "excel", type=Path, help="The Excel file to parse", metavar="EXCEL"
     )
     parser.add_argument(
-        "--sheet",
-        action="append",
+        "--sheets",
+        nargs="+",
         default=[],
         help="Excel sheet name(s) to import (default: all sheets)",
     )
@@ -142,11 +142,11 @@ if __name__ == "__main__":
         ["ID", "Language_ID", "Parameter_ID", "Form", "Comment", "Cognateset_ID"]
     )
 
-    if not args.sheet:
-        args.sheet = [sheet for sheet in ws.sheetnames]
+    if not args.sheets:
+        args.sheets = [sheet for sheet in ws.sheetnames]
 
     ids: t.Set[str] = set()
-    for sheetname in args.sheet:
+    for sheetname in args.sheets:
         sheet = ws[sheetname]
         for row in import_interleaved(sheet, logger=logger, ids=ids):
             w.writerow(row)

--- a/src/lexedata/importer/excel_interleaved.py
+++ b/src/lexedata/importer/excel_interleaved.py
@@ -127,7 +127,7 @@ if __name__ == "__main__":
         "--directory",
         type=Path,
         default=Path(os.getcwd()),
-        help="Path to directory where forms.csv is created (default: current working directory)",
+        help="Path to directory where forms.csv is to be created (default: current working directory)",
     )
     cli.add_log_controls(parser)
     args = parser.parse_args()

--- a/src/lexedata/importer/excel_long_format.py
+++ b/src/lexedata/importer/excel_long_format.py
@@ -362,18 +362,17 @@ if __name__ == "__main__":
         metavar="COLUMN",
     )
     parser.add_argument(
-        "--sheet",
-        action="append",
+        "--sheets",
         type=str,
-        default=[],
+        nargs="+",
         metavar="SHEET_NAME",
-        help="Sheet to parse. For multiple sheets, use multiple arguments of the shape --sheet Name1 --sheet Name2 (default: all sheets)",
+        help="Sheets to parse. (default: all sheets)",
     )
     parser.add_argument(
         "--match-form",
         "-f",
-        action="append",
         type=str,
+        nargs="+",
         default=[],
         metavar="COLUMN_NAME",
         help="Forms are considered identical if all columns passed to -f/--match-form are identical",
@@ -418,13 +417,13 @@ if __name__ == "__main__":
     args = parser.parse_args()
     logger = cli.setup_logging(args)
 
-    if not args.sheet:
+    if not args.sheets:
         sheets = [
             sheet for sheet in args.excel if sheet.title not in args.exclude_sheet
         ]
-        logger.info("No sheets specified explicitly. Parsing sheets: %s", args.sheet)
+        logger.info("No sheets specified explicitly. Parsing sheets: %s", args.sheets)
     else:
-        sheets = [args.excel[s] for s in args.sheet]
+        sheets = [args.excel[s] for s in args.sheets]
 
     report = add_single_languages(
         metadata=args.metadata,

--- a/src/lexedata/report/coverage.py
+++ b/src/lexedata/report/coverage.py
@@ -213,13 +213,11 @@ if __name__ == "__main__":
         help="Only list matching languages, don't report statistics",
     )
     parser.add_argument(
-        "--with-concept",
+        "--with-concepts",
         "-c",
-        action="append",
-        default=[],
-        type=str,
-        help="Only include languages that have a form for CONCEPT",
+        action=cli.ListOrFromFile,
         metavar="CONCEPT",
+        help="Only include languages that have a form for each CONCEPT.",
     )
     parser.add_argument(
         "--concept-report",

--- a/src/lexedata/report/coverage.py
+++ b/src/lexedata/report/coverage.py
@@ -253,7 +253,7 @@ if __name__ == "__main__":
     data, header = coverage_report(
         dataset,
         args.min_percentage,
-        args.with_concept,
+        args.with_concepts,
         missing=Missing.__members__[args.missing],
         only_coded=args.coded,
     )

--- a/src/lexedata/report/filter.py
+++ b/src/lexedata/report/filter.py
@@ -112,8 +112,8 @@ if __name__ == "__main__":
 
     if not args.table:
         table = DictReader(sys.stdin)
-        if not args.output_column:
-            args.output_column = table.fieldnames
+        if not args.output_columns:
+            args.output_columns = table.fieldnames
     else:
         table = pycldf.Wordlist.from_metadata(args.metadata)[args.table]
 
@@ -122,13 +122,13 @@ if __name__ == "__main__":
         for r, row in enumerate(
             filter(table, args.column, re.compile(args.filter), args.invert)
         ):
-            if not args.output_column:
-                args.output_column = row.keys()
+            if not args.output_columns:
+                args.output_columns = row.keys()
             if w is None:
-                w = DictWriter(sys.stdout, args.output_column)
+                w = DictWriter(sys.stdout, args.output_columns)
                 w.writeheader()
             row = {
-                key: value for key, value in row.items() if key in args.output_column
+                key: value for key, value in row.items() if key in args.output_columns
             }
             w.writerow(row)
     except KeyError:

--- a/src/lexedata/report/filter.py
+++ b/src/lexedata/report/filter.py
@@ -1,5 +1,6 @@
 """Filter some table by some column.
 
+
 Print the partial table to STDOUT or a file, so it can be used as subset-filter
 for some other script, and output statistics (how many included, how many
 excluded, what proportion, maybe sub-statistics for xxxReference columns, i.e.
@@ -76,7 +77,9 @@ def filter(
 
 
 def parser():
-    parser = cli.parser(description=__doc__)
+    parser = cli.parser(
+        description=__doc__.split("\n\n\n")[0], epilog=__doc__.split("\n\n\n")[1]
+    )
     parser.add_argument("column", help="The column to filter.", metavar="COLUMN")
     parser.add_argument("filter", help="An expression to filter by.", metavar="FILTER")
     parser.add_argument(

--- a/src/lexedata/report/filter.py
+++ b/src/lexedata/report/filter.py
@@ -93,9 +93,9 @@ def parser():
         help="Output exactly the NON-matching lines",
     )
     parser.add_argument(
-        "--output-column",
+        "--output-columns",
         "-c",
-        action="append",
+        nargs="+",
         default=[],
         help="Output only columns OUTPUT_COLUMN1,OUTPUT_COLUMN2,OUTPUT_COLUMN3,… in the same order as given.",
     )

--- a/src/lexedata/report/segment_inventories.py
+++ b/src/lexedata/report/segment_inventories.py
@@ -66,10 +66,9 @@ if __name__ == "__main__":
         description=__doc__.split("\n\n\n")[0], epilog=__doc__.split("\n\n\n")[1]
     )
     parser.add_argument(
-        "--language",
-        action="append",
-        default=[],
-        help="Restrict the report to these lanugage id(s). (default: All languages.)",
+        "--languages",
+        action=cli.ListOrFromFile,
+        help="Restrict the report to these lanugage id(s).",
     )
     args = parser.parse_args()
     logger = cli.setup_logging(args)

--- a/src/lexedata/report/segment_inventories.py
+++ b/src/lexedata/report/segment_inventories.py
@@ -75,10 +75,7 @@ if __name__ == "__main__":
 
     dataset = pycldf.Wordlist.from_metadata(args.metadata)
 
-    if not args.language:
-        args.language = types.WorldSet()
-
-    counts = count_segments(dataset, args.language)
+    counts = count_segments(dataset, args.languages)
 
     if len(counts) == 1:
         # A single language

--- a/test/test_various_parsers.py
+++ b/test/test_various_parsers.py
@@ -8,7 +8,7 @@ def test_filter_parser():
     assert parameters.column == "form"
     assert parameters.filter == "a"
     assert parameters.invert is True
-    assert parameters.output_column == []
+    assert parameters.output_columns == []
 
 
 def test_loglevel_parser():

--- a/test/test_various_parsers.py
+++ b/test/test_various_parsers.py
@@ -1,5 +1,29 @@
 import logging
+import tempfile
+import argparse
+from lexedata import cli
 from lexedata.report.filter import parser as filter_parser
+
+
+def test_listorfromfile_list():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--objects", action=cli.ListOrFromFile, help="Some objects.")
+    parser.add_argument("--other", action="store_true", default=False)
+    parameters = parser.parse_args(["--objects", "o1", "o2", "o3", "--other"])
+    assert parameters.other
+    assert parameters.objects == ["o1", "o2", "o3"]
+
+
+def test_listorfromfile_file():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--objects", action=cli.ListOrFromFile, help="Some objects.")
+    parser.add_argument("--other", action="store_true", default=False)
+    _, fname = tempfile.mkstemp(".csv")
+    with open(fname, "w") as file:
+        file.write("ID,ignored\no1,yes\no2\no3,")
+    parameters = parser.parse_args(["--objects", fname, "--other"])
+    assert parameters.other
+    assert parameters.objects == ["o1", "o2", "o3"]
 
 
 def test_filter_parser():


### PR DESCRIPTION
Clean up the various types of list arguments so that two remain:
 - For objects from the database automatically accepting both `--concepts CONCEPT1 CONCEPT2 CONCEPT3` and `--concepts CONCEPTS.CSV`.
 - `--sheets SHEET1 SHEET2 SHEET3` otherwise.

No more `--language-list`, no more `--sheet S1 --sheet S2`.

Fixes #268.