### PR TITLE
Install different python versions for tests

### DIFF
--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -19,6 +19,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: Install pycldf ${{ matrix.pycldf }}
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Going through #297, I was surprised to see this was not caught by your continuous integration. It looks like you forgot to actually install the different python versions.